### PR TITLE
Fix recursive inclusion of the toolbar page

### DIFF
--- a/code/GlobalNavIteratorProperties.php
+++ b/code/GlobalNavIteratorProperties.php
@@ -9,9 +9,15 @@ class GlobalNavIteratorProperties implements TemplateIteratorProvider {
 	}
 
 	public function iteratorProperties($pos, $totalItems) {
+		// If we're already in a toolbarrequest, don't recurse further
+		// This is most likely to happen during a 404
+		if (!empty($_GET['globaltoolbar'])) {
+			$this->globalNav = '';
+			return;
+		}
 		$host = GlobalNavSiteTreeExtension::get_toolbar_hostname();
 		$path = Config::inst()->get('GlobalNav','snippet_path');
-		$html = @file_get_contents(Controller::join_links($host,$path));
+		$html = @file_get_contents(Controller::join_links($host, $path, '?globaltoolbar=true'));
 		if (empty($html)) {
 			$this->globalNav = '';
 		}


### PR DESCRIPTION
This is most likely to happen during a 404 page which includes
the toolbar, which includes the toolbar which is a 404 page, which
includes...
