### PR TITLE
BUG Fix broken absolute link when run in subdirectory

### DIFF
--- a/code/GlobalNavSiteTreeExtension.php
+++ b/code/GlobalNavSiteTreeExtension.php
@@ -53,7 +53,7 @@ class GlobalNavSiteTreeExtension extends DataExtension {
 		if($this->owner instanceof RedirectorPage && $this->owner->ExternalURL) {
 			return $this->owner->ExternalURL;
 		}
-		return Controller::join_links(Director::absoluteBaseURL(), $this->owner->Link());
+		return $this->owner->AbsoluteLink();
 	}
 
 


### PR DESCRIPTION
absoluteBaseUrl and Link already append the BaseDir. Joining these means they end up included twice.
