### PR TITLE
Use simpler (and faster) file_get_contents() on local if configured

### DIFF
--- a/code/GlobalNavTemplateProvider.php
+++ b/code/GlobalNavTemplateProvider.php
@@ -57,11 +57,15 @@ class GlobalNavTemplateProvider implements TemplateGlobalProvider {
 			if (empty($_GET['globaltoolbar'])) {
 				$host = GlobalNavSiteTreeExtension::get_toolbar_hostname();
 				$path = Config::inst()->get('GlobalNav','snippet_path');
-				$url = Controller::join_links($host, $path, '?globaltoolbar=true');
-				$connectionTimeout = Config::inst()->get('GlobalNavTemplateProvider', 'connection_timeout');
-				$transferTimeout = Config::inst()->get('GlobalNavTemplateProvider', 'transfer_timeout');
-				// Get the HTML and cache it
-				self::$global_nav_html = self::curl_call($url, $connectionTimeout, $transferTimeout);
+				if(Config::inst()->get('GlobalNav', 'use_localhost')) {
+					self::$global_nav_html = file_get_contents(BASE_PATH . $path);
+				} else {
+					$url = Controller::join_links($host, $path, '?globaltoolbar=true');
+					$connectionTimeout = Config::inst()->get('GlobalNavTemplateProvider', 'connection_timeout');
+					$transferTimeout = Config::inst()->get('GlobalNavTemplateProvider', 'transfer_timeout');
+					// Get the HTML and cache it
+					self::$global_nav_html = self::curl_call($url, $connectionTimeout, $transferTimeout);
+				}
 			}
 		}
 


### PR DESCRIPTION
Rather than doing a full HTTP request to get a local asset, just use
a quick file_get_contents() call to grab the HTML.
