### PR TITLE
FIX Curl to follow redirects and exclude header in response

### DIFF
--- a/code/GlobalNavTemplateProvider.php
+++ b/code/GlobalNavTemplateProvider.php
@@ -107,6 +107,8 @@ class GlobalNavTemplateProvider implements TemplateGlobalProvider {
 
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+		curl_setopt($ch, CURLOPT_HEADER, false);
 		curl_setopt($ch, CURLOPT_TIMEOUT_MS, $timeoutMs);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, $connectTimeoutMs);
 


### PR DESCRIPTION
This is the cause of the current issue where all SilverStripe docs websites have no global navigation.