### PR TITLE
NEW: Add 5.x branch alias in lead-up to 5.0.0-rc1 tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		"psr-4": {
 			"SilverStripe\\Toolbar\\": "src/"
 		}
-	},	
+	},
 	"authors":[
 		{
 			"name": "Ingo Schommer",
@@ -24,6 +24,10 @@
 			"homepage": "http://leftandmain.com",
 			"email" : "unclecheese@leftandmain.com"
 		}
-
-	]
+	],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "5.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
Once this is merged it would also be good to create a 5.0.0-rc1 or 5.0.0-beta1 tag as you see fit.

5.x is the SS4-compatible version