### PR TITLE
Loosen displaylogic constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"license": "BSD-3-Clause",
 	"homepage": "https://github.com/silverstripe/silverstripe-globaltoolbar/",
 	"require": {
-        "unclecheese/display-logic": "1.3.*"
+        "unclecheese/display-logic": "~1.3"
 	},
 	"authors":[
 		{


### PR DESCRIPTION
Allows deployments of PHP 7.2+ on a SS 3.x site such as silverstripe.org.
Note that the 5.x/master branch of this no longer requires displaylogic.
And that there's no `4` branch, just `4.2`.