### PR TITLE
FIX: Update GlobalNavbar template to support ssorg navigation changes

### DIFF
--- a/templates/GlobalNavbar.ss
+++ b/templates/GlobalNavbar.ss
@@ -1,88 +1,88 @@
 <nav class="navbar navbar-global" role="navigation" id="NavbarGlobal">
-	<div class="container-fluid">
-		<div class="navbar-header">
+    <div class="container-fluid">
+        <div class="navbar-header">
 
-			<a class="navbar-menu js-nav-trigger hidden-xs hidden-sm">
-				<span class="sr-only">Site Navigation</span>
-				<span class="icon ion-navicon-round"></span>
-			</a>
+            <a class="navbar-menu js-nav-trigger hidden-xs hidden-sm">
+                <span class="sr-only">Site Navigation</span>
+                <span class="icon ion-navicon-round"></span>
+            </a>
 
-			<div class="navbar-brand">
-				<h1 class="brand-name">
-					<a class="logo" title="SilverStripe" href="$Scope.Level(1).Link">
-						<img class="global-logo" src="{$ToolbarHostname}/themes/ssv3/img/global-logo-<% if $Scope.Level(1) %>{$Scope.Level(1).URLSegment}<% else %>open-source<% end_if %>.svg" alt="{$Scope.Menu(1).Title}">
-					</a>
-				</h1>
-			</div>
+            <div class="navbar-brand">
+                <h1 class="brand-name">
+                    <a class="logo" title="SilverStripe" href="$Scope.Level(1).Link">
+                        <img class="global-logo" src="{$ToolbarHostname}/themes/ssv3/img/global-logo-<% if $Scope.Level(1) %>{$Scope.Level(1).URLSegment}<% else %>open-source<% end_if %>.svg" alt="{$Scope.Menu(1).Title}">
+                    </a>
+                </h1>
+            </div>
 
-			<a class="js-nav-expander navbar-menu nav-expander fixed visible-xs visible-sm">
-				<span class="icon ion-navicon-round"></span>
-				<span class="sr-only">Mobile site navigation</span>
-			</a>
-		</div>
+            <a class="js-nav-expander navbar-menu nav-expander fixed visible-xs visible-sm">
+                <span class="icon ion-navicon-round"></span>
+                <span class="sr-only">Mobile site navigation</span>
+            </a>
+        </div>
 
-		<%-- Profile menu --%>
-		<ul id="profile-menu" class="nav navbar-nav global-right pull-right" style="display:none;">
-			<li class="nav-search">
-				<button class="search" aria-label="Search site" data-toggle="modal" data-target="#modalSearch">
-					<% include SearchSvg %>
-				</button>
-			</li>
+        <%-- Profile menu --%>
+        <ul id="profile-menu" class="nav navbar-nav global-right pull-right" style="display:none;">
+            <li class="nav-search">
+                <button class="search" aria-label="Search site" data-toggle="modal" data-target="#modalSearch">
+                    <% include SearchSvg %>
+                </button>
+            </li>
 
-			<li class="hidden-xs hidden-sm">
-				<iframe id="toolbar-iframe" src="{$ToolbarHostname}/toolbar/profile" frameborder="0" width="0" scrolling="no"></iframe>
-			</li>
-		</ul>
-		<i id="loader-menu" class="loader-profile pull-right icon icon-xs ion-ios-reloading"></i>
-		<%-- Navigation top level --%>
-		<ul class="nav navbar-nav global-nav hidden-xs hidden-sm" role="navigation">
-			<% loop $Scope.Menu(2) %><li class="dropdown-hover <% if $Top.ActivePage.ID == $ID %>current<% else_if $Top.ActivePage.InNode($ID) %>section<% end_if %>"><a href="$GlobalNavLink" title="Go to the $Title.XML page" class="dropdown-toggle">$MenuTitle.XML</a><% include GlobalNav_secondary_pages ActivePageID=$Top.ActivePage.ID, ActiveParentID=$Top.ActivePage.ParentID, Pages=$GlobalNavChildren %></li><% end_loop %>
-		</ul>
+            <li class="hidden-xs hidden-sm">
+                <iframe id="toolbar-iframe" src="{$ToolbarHostname}/toolbar/profile" frameborder="0" width="0" scrolling="no"></iframe>
+            </li>
+        </ul>
+        <i id="loader-menu" class="loader-profile pull-right icon icon-xs ion-ios-reloading"></i>
+        <%-- Navigation top level --%>
+        <ul class="nav navbar-nav global-nav hidden-xs hidden-sm" role="navigation">
+            <% loop $Scope.Menu(2) %><li class="dropdown-hover <% if $Top.ActivePage.ID == $ID %>current<% else_if $Top.ActivePage.InNode($ID) %>section<% end_if %>"><a href="$GlobalNavLink" title="Go to the $Title.XML page" class="dropdown-toggle">$MenuTitle.XML</a><% include GlobalNav_secondary_pages ActivePageID=$Top.ActivePage.ID, ActiveParentID=$Top.ActivePage.ParentID, Pages=$GlobalNavChildren %></li><% end_loop %>
+        </ul>
 
-		<nav class="slide-menu visible-xs visible-sm" role="navigation">
-			<ul class="nav">
-				<li class="mobile-nav-login pull-left">
-					<iframe id="toolbar-iframe-mobile" src="{$ToolbarHostname}/toolbar/profile" frameborder="0" width="0" scrolling="no"></iframe>
-				</li>
-				<li class="text-right"><a id="nav-close" class="ion-ios-close-empty"></a></li>
-				<% loop $Scope.Menu(1) %>
-				<li class="$LinkingMode<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
-					<% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
-					<a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
-					<% if $GlobalNavChildren %>
-					<ul class="<% if $Top.ActivePage.ID == $ID || $Top.ActivePage.ParentID == $ID %> collapsed in<% else %> collapse<% end_if %> list-unstyled" id="nav-{$ID}" role="menu">
-						<% loop Children %>
-						<li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
-							<% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
-							<a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
-							<% if $GlobalNavChildren %>
-							<ul class="<% if $Top.ActivePage.ID == $ID || $Top.ActivePage.ParentID == $ID %> collapsed in<% else %> collapse<% end_if %> list-unstyled" id="nav-{$ID}" role="menu">
-								<% loop Children %>
-								<li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
-									<% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
-									<a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
-									<% if $GlobalNavChildren %>
-									<ul class="collapse list-unstyled" id="nav-{$ID}" role="menu">
-										<% loop Children %>
-										<li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
-											<a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML</a>
-										</li>
-										<% end_loop %>
-									</ul>
-									<% end_if %>
-								</li>
-								<% end_loop %>
-							</ul>
-							<% end_if %>
-						</li>
-						<% end_loop %>
-					</ul>
-					<% end_if %>
-				</li>
-				<% end_loop %>
-			</ul>
-		</nav>
-	</div>
+        <nav class="slide-menu visible-xs visible-sm" role="navigation">
+            <ul class="nav">
+                <li class="mobile-nav-login pull-left">
+                    <iframe id="toolbar-iframe-mobile" src="{$ToolbarHostname}/toolbar/profile" frameborder="0" width="0" scrolling="no"></iframe>
+                </li>
+                <li class="text-right"><a id="nav-close" class="ion-ios-close-empty"></a></li>
+                <% loop $Scope.Menu(1) %>
+                <li class="$LinkingMode<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
+                    <% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
+                    <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
+                    <% if $GlobalNavChildren %>
+                    <ul class="<% if $Top.ActivePage.ID == $ID || $Top.ActivePage.ParentID == $ID %> collapsed in<% else %> collapse<% end_if %> list-unstyled" id="nav-{$ID}" role="menu">
+                        <% loop Children %>
+                        <li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
+                            <% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
+                            <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
+                            <% if $GlobalNavChildren %>
+                            <ul class="<% if $Top.ActivePage.ID == $ID || $Top.ActivePage.ParentID == $ID %> collapsed in<% else %> collapse<% end_if %> list-unstyled" id="nav-{$ID}" role="menu">
+                                <% loop Children %>
+                                <li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
+                                    <% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
+                                    <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
+                                    <% if $GlobalNavChildren %>
+                                    <ul class="collapse list-unstyled" id="nav-{$ID}" role="menu">
+                                        <% loop Children %>
+                                        <li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
+                                            <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML</a>
+                                        </li>
+                                        <% end_loop %>
+                                    </ul>
+                                    <% end_if %>
+                                </li>
+                                <% end_loop %>
+                            </ul>
+                            <% end_if %>
+                        </li>
+                        <% end_loop %>
+                    </ul>
+                    <% end_if %>
+                </li>
+                <% end_loop %>
+            </ul>
+        </nav>
+    </div>
 </nav>
 
 <%-- Mega nav popup --%>
@@ -94,123 +94,123 @@
 <script type="text/javascript">
 
 (function() {
-	// Define some utility functions - we can't use jQuery, from http://youmightnotneedjquery.com/.
-	function elHasClass(el, className) {
-		if (el.classList) {
-			return el.classList.contains(className);
-		} else {
-			return new RegExp('(^| )' + className + '( |$)', 'gi').test(el.className);
-		}
-	}
+    // Define some utility functions - we can't use jQuery, from http://youmightnotneedjquery.com/.
+    function elHasClass(el, className) {
+        if (el.classList) {
+            return el.classList.contains(className);
+        } else {
+            return new RegExp('(^| )' + className + '( |$)', 'gi').test(el.className);
+        }
+    }
 
-	function elAddClass(el, className) {
-		if (el.classList) {
-			el.classList.add(className);
-		} else {
-			el.className += ' ' + className;
-		}
-	}
+    function elAddClass(el, className) {
+        if (el.classList) {
+            el.classList.add(className);
+        } else {
+            el.className += ' ' + className;
+        }
+    }
 
-	function elRemoveClass(el, kls) {
-		if (el.classList) {
-			el.classList.remove(kls);
-		} else {
-			el.className = el.className.replace(' ' + kls, '');
-		}
-	}
+    function elRemoveClass(el, kls) {
+        if (el.classList) {
+            el.classList.remove(kls);
+        } else {
+            el.className = el.className.replace(' ' + kls, '');
+        }
+    }
 
-	function elToggleClass(el, className) {
-		if(el.classList) {
-			el.classList.toggle(className);
-		} else if (elHasClass(el, className)) {
-			elRemoveClass(el, className);
-		} else {
-			elAddClass(el, className);
-		}
-	}
+    function elToggleClass(el, className) {
+        if(el.classList) {
+            el.classList.toggle(className);
+        } else if (elHasClass(el, className)) {
+            elRemoveClass(el, className);
+        } else {
+            elAddClass(el, className);
+        }
+    }
 
-	(function() {
-	    var MQL = 1170;
-	    var q = function (sel) {
-	    	return document.querySelector(sel);
-	    };
-	    //primary navigation slide-in effect for pop out mega navigation
-	    if(window.innerWidth > MQL) {
-	        var headerHeight = q('.site-header').offsetHeight;
-	        window.addEventListener('scroll', function () {
-	            var currentTop = window.scrollTop;
-	            //check if user is scrolling up
-	            if (currentTop < this.previousTop ) {
-	                //if scrolling up...
-	                if (currentTop > 0 && elHasClass(q('.site-header'),'is-fixed')) {
-	                    elAddClass(q('.site-header'),'is-visible');
-	                } else {
-	                    elRemoveClass(q('.site-header'),'is-visible is-fixed');
-	                }
-	            } else {
-	                //if scrolling down...
-	                elRemoveClass(q('.site-header'),'is-visible');
-	                if( currentTop > headerHeight && !elHasClass(q('.site-header'),'is-fixed')) {
-	                	elAddClass(q('.site-header'),'is-fixed');
-	                }
-	            }
-	            this.previousTop = currentTop;
-	        });
-	    }
+    (function() {
+        var MQL = 1170;
+        var q = function (sel) {
+            return document.querySelector(sel);
+        };
+        //primary navigation slide-in effect for pop out mega navigation
+        if(window.innerWidth > MQL) {
+            var headerHeight = q('.site-header').offsetHeight;
+            window.addEventListener('scroll', function () {
+                var currentTop = window.scrollTop;
+                //check if user is scrolling up
+                if (currentTop < this.previousTop ) {
+                    //if scrolling up...
+                    if (currentTop > 0 && elHasClass(q('.site-header'),'is-fixed')) {
+                        elAddClass(q('.site-header'),'is-visible');
+                    } else {
+                        elRemoveClass(q('.site-header'),'is-visible is-fixed');
+                    }
+                } else {
+                    //if scrolling down...
+                    elRemoveClass(q('.site-header'),'is-visible');
+                    if( currentTop > headerHeight && !elHasClass(q('.site-header'),'is-fixed')) {
+                        elAddClass(q('.site-header'),'is-fixed');
+                    }
+                }
+                this.previousTop = currentTop;
+            });
+        }
 
-	    //open/close primary pop out mega navigation
-	    var triggers = document.querySelectorAll('.js-nav-trigger');
-	    [].forEach.call(triggers, function (node) {
-		    node.addEventListener('click', function() {
-		        elToggleClass(q('.site-header'), 'menu-is-open');
-		        elToggleClass(q('.popup-primary-nav'),'open');
-		    });
+        //open/close primary pop out mega navigation
+        var triggers = document.querySelectorAll('.js-nav-trigger');
+        [].forEach.call(triggers, function (node) {
+            node.addEventListener('click', function() {
+                elToggleClass(q('.site-header'), 'menu-is-open');
+                elToggleClass(q('.popup-primary-nav'),'open');
+            });
 
-	    })
-	})();
+        })
+    })();
 
-	(function() {
-		document.addEventListener('DOMContentLoaded', function () {
-			iFrameResize({
-				enablePublicMethods: true,
-				sizeWidth: true,
-				autoResize: false,
-				log: false
-			}, '#toolbar-iframe');
+    (function() {
+        document.addEventListener('DOMContentLoaded', function () {
+            iFrameResize({
+                enablePublicMethods: true,
+                sizeWidth: true,
+                autoResize: false,
+                log: false
+            }, '#toolbar-iframe');
 
-			iFrameResize({
-				enablePublicMethods: true,
-				sizeWidth: true,
-				autoResize: false,
-				log: false
-			}, '#toolbar-iframe-mobile');
+            iFrameResize({
+                enablePublicMethods: true,
+                sizeWidth: true,
+                autoResize: false,
+                log: false
+            }, '#toolbar-iframe-mobile');
 
-			setTimeout(function() {
-				document.getElementById('profile-menu').style.display='block';
-				document.getElementById('loader-menu').style.display='none';
-			}, 1000);
-		});
-	})();
+            setTimeout(function() {
+                document.getElementById('profile-menu').style.display='block';
+                document.getElementById('loader-menu').style.display='none';
+            }, 1000);
+        });
+    })();
 
-	(function() {
-		var interval = window.setInterval(function() {
-			for(var i=1;i<=3;i++) {
-				if(document.getElementById('gsc-i-id'+i)) {
-					window.clearInterval(interval);
-					document.getElementById('gsc-i-id'+i).setAttribute('placeholder', 'Search SilverStripe...');
-				}
+    (function() {
+        var interval = window.setInterval(function() {
+            for(var i=1;i<=3;i++) {
+                if(document.getElementById('gsc-i-id'+i)) {
+                    window.clearInterval(interval);
+                    document.getElementById('gsc-i-id'+i).setAttribute('placeholder', 'Search SilverStripe...');
+                }
 
-			}
-		}.bind(this), 500);
-	})();
+            }
+        }.bind(this), 500);
+    })();
 
-	(function() {
-		var cx = '$GoogleCustomSearchId';
-		var gcse = document.createElement('script'); gcse.type = 'text/javascript'; gcse.async = true;
-		gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
-			'//www.google.com/cse/cse.js?cx=' + cx;
-			var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gcse, s);
-	})();
+    (function() {
+        var cx = '$GoogleCustomSearchId';
+        var gcse = document.createElement('script'); gcse.type = 'text/javascript'; gcse.async = true;
+        gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
+            '//www.google.com/cse/cse.js?cx=' + cx;
+            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gcse, s);
+    })();
 
 })();
 

--- a/templates/GlobalNavbar.ss
+++ b/templates/GlobalNavbar.ss
@@ -1,7 +1,6 @@
 <nav class="navbar navbar-global" role="navigation" id="NavbarGlobal">
     <div class="container-fluid">
         <div class="navbar-header">
-
             <a class="navbar-menu js-nav-trigger hidden-xs hidden-sm">
                 <span class="sr-only">Site Navigation</span>
                 <span class="icon ion-navicon-round"></span>
@@ -9,8 +8,8 @@
 
             <div class="navbar-brand">
                 <h1 class="brand-name">
-                    <a class="logo" title="SilverStripe" href="$Scope.Level(1).Link">
-                        <img class="global-logo" src="{$ToolbarHostname}/themes/ssv3/img/global-logo-<% if $Scope.Level(1) %>{$Scope.Level(1).URLSegment}<% else %>open-source<% end_if %>.svg" alt="{$Scope.Menu(1).Title}">
+                    <a class="logo" title="SilverStripe" href="$ToolbarHostname">
+                        <img class="global-logo" src="{$ToolbarHostname}/themes/ssv3/img/global-logo-home.svg" alt="{$Scope.Page(home).Title}">
                     </a>
                 </h1>
             </div>
@@ -36,7 +35,7 @@
         <i id="loader-menu" class="loader-profile pull-right icon icon-xs ion-ios-reloading"></i>
         <%-- Navigation top level --%>
         <ul class="nav navbar-nav global-nav hidden-xs hidden-sm" role="navigation">
-            <% loop $Scope.Menu(2) %><li class="dropdown-hover <% if $Top.ActivePage.ID == $ID %>current<% else_if $Top.ActivePage.InNode($ID) %>section<% end_if %>"><a href="$GlobalNavLink" title="Go to the $Title.XML page" class="dropdown-toggle">$MenuTitle.XML</a><% include GlobalNav_secondary_pages ActivePageID=$Top.ActivePage.ID, ActiveParentID=$Top.ActivePage.ParentID, Pages=$GlobalNavChildren %></li><% end_loop %>
+            <% loop $Scope.Menu(1) %><li class="dropdown-hover <% if $Top.ActivePage.ID == $ID %>current<% else_if $Top.ActivePage.InNode($ID) %>section<% end_if %>"><a href="$GlobalNavLink" title="Go to the $Title.XML page" class="dropdown-toggle">$MenuTitle.XML</a><% include GlobalNav_secondary_pages ActivePageID=$Top.ActivePage.ID, ActiveParentID=$Top.ActivePage.ParentID, Pages=$GlobalNavChildren %></li><% end_loop %>
         </ul>
 
         <nav class="slide-menu visible-xs visible-sm" role="navigation">
@@ -45,40 +44,40 @@
                     <iframe id="toolbar-iframe-mobile" src="{$ToolbarHostname}/toolbar/profile" frameborder="0" width="0" scrolling="no"></iframe>
                 </li>
                 <li class="text-right"><a id="nav-close" class="ion-ios-close-empty"></a></li>
-                <% loop $Scope.Menu(1) %>
-                <li class="$LinkingMode<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
-                    <% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
-                    <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
-                    <% if $GlobalNavChildren %>
-                    <ul class="<% if $Top.ActivePage.ID == $ID || $Top.ActivePage.ParentID == $ID %> collapsed in<% else %> collapse<% end_if %> list-unstyled" id="nav-{$ID}" role="menu">
-                        <% loop Children %>
-                        <li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
-                            <% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
-                            <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
-                            <% if $GlobalNavChildren %>
+                <% loop $Scope.GlobalNavItems %>
+                    <li class="$LinkingMode<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
+                        <% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
+                        <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
+                        <% if $GlobalNavChildren %>
                             <ul class="<% if $Top.ActivePage.ID == $ID || $Top.ActivePage.ParentID == $ID %> collapsed in<% else %> collapse<% end_if %> list-unstyled" id="nav-{$ID}" role="menu">
-                                <% loop Children %>
-                                <li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
-                                    <% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
-                                    <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
-                                    <% if $GlobalNavChildren %>
-                                    <ul class="collapse list-unstyled" id="nav-{$ID}" role="menu">
-                                        <% loop Children %>
-                                        <li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
-                                            <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML</a>
-                                        </li>
-                                        <% end_loop %>
-                                    </ul>
-                                    <% end_if %>
-                                </li>
+                                <% loop GlobalNavChildren %>
+                                    <li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
+                                        <% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
+                                        <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
+                                        <% if $GlobalNavChildren %>
+                                            <ul class="<% if $Top.ActivePage.ID == $ID || $Top.ActivePage.ParentID == $ID %> collapsed in<% else %> collapse<% end_if %> list-unstyled" id="nav-{$ID}" role="menu">
+                                                <% loop GlobalNavChildren %>
+                                                    <li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
+                                                        <% if $GlobalNavChildren %><span data-toggle="collapse" data-target="#nav-{$ID}" class="icon ion-ios-arrow-down"></span><% end_if %>
+                                                        <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML<% if $GlobalNavChildren %><% else %><span class="icon ion-ios-arrow-right"></span><% end_if %></a>
+                                                        <% if $GlobalNavChildren %>
+                                                            <ul class="collapse list-unstyled" id="nav-{$ID}" role="menu">
+                                                                <% loop GlobalNavChildren %>
+                                                                    <li class="$LinkingMode sub-nav<% if $GlobalNavChildren %> children<% end_if %><% if $Top.ActivePage.ID == $ID %> current<% else_if $Top.ActivePage.ParentID == $ID %> section<% end_if %>">
+                                                                        <a href="$GlobalNavLink" title="Go to the $Title.XML page">$MenuTitle.XML</a>
+                                                                    </li>
+                                                                <% end_loop %>
+                                                            </ul>
+                                                        <% end_if %>
+                                                    </li>
+                                                <% end_loop %>
+                                            </ul>
+                                        <% end_if %>
+                                    </li>
                                 <% end_loop %>
                             </ul>
-                            <% end_if %>
-                        </li>
-                        <% end_loop %>
-                    </ul>
-                    <% end_if %>
-                </li>
+                        <% end_if %>
+                    </li>
                 <% end_loop %>
             </ul>
         </nav>
@@ -93,125 +92,125 @@
 <script type="text/javascript" src="{$ToolbarHostname}/toolbar/js/bootstrap/modal.js"></script>
 <script type="text/javascript">
 
-(function() {
-    // Define some utility functions - we can't use jQuery, from http://youmightnotneedjquery.com/.
-    function elHasClass(el, className) {
-        if (el.classList) {
-            return el.classList.contains(className);
-        } else {
-            return new RegExp('(^| )' + className + '( |$)', 'gi').test(el.className);
-        }
-    }
-
-    function elAddClass(el, className) {
-        if (el.classList) {
-            el.classList.add(className);
-        } else {
-            el.className += ' ' + className;
-        }
-    }
-
-    function elRemoveClass(el, kls) {
-        if (el.classList) {
-            el.classList.remove(kls);
-        } else {
-            el.className = el.className.replace(' ' + kls, '');
-        }
-    }
-
-    function elToggleClass(el, className) {
-        if(el.classList) {
-            el.classList.toggle(className);
-        } else if (elHasClass(el, className)) {
-            elRemoveClass(el, className);
-        } else {
-            elAddClass(el, className);
-        }
-    }
-
     (function() {
-        var MQL = 1170;
-        var q = function (sel) {
-            return document.querySelector(sel);
-        };
-        //primary navigation slide-in effect for pop out mega navigation
-        if(window.innerWidth > MQL) {
-            var headerHeight = q('.site-header').offsetHeight;
-            window.addEventListener('scroll', function () {
-                var currentTop = window.scrollTop;
-                //check if user is scrolling up
-                if (currentTop < this.previousTop ) {
-                    //if scrolling up...
-                    if (currentTop > 0 && elHasClass(q('.site-header'),'is-fixed')) {
-                        elAddClass(q('.site-header'),'is-visible');
-                    } else {
-                        elRemoveClass(q('.site-header'),'is-visible is-fixed');
-                    }
-                } else {
-                    //if scrolling down...
-                    elRemoveClass(q('.site-header'),'is-visible');
-                    if( currentTop > headerHeight && !elHasClass(q('.site-header'),'is-fixed')) {
-                        elAddClass(q('.site-header'),'is-fixed');
-                    }
-                }
-                this.previousTop = currentTop;
-            });
-        }
-
-        //open/close primary pop out mega navigation
-        var triggers = document.querySelectorAll('.js-nav-trigger');
-        [].forEach.call(triggers, function (node) {
-            node.addEventListener('click', function() {
-                elToggleClass(q('.site-header'), 'menu-is-open');
-                elToggleClass(q('.popup-primary-nav'),'open');
-            });
-
-        })
-    })();
-
-    (function() {
-        document.addEventListener('DOMContentLoaded', function () {
-            iFrameResize({
-                enablePublicMethods: true,
-                sizeWidth: true,
-                autoResize: false,
-                log: false
-            }, '#toolbar-iframe');
-
-            iFrameResize({
-                enablePublicMethods: true,
-                sizeWidth: true,
-                autoResize: false,
-                log: false
-            }, '#toolbar-iframe-mobile');
-
-            setTimeout(function() {
-                document.getElementById('profile-menu').style.display='block';
-                document.getElementById('loader-menu').style.display='none';
-            }, 1000);
-        });
-    })();
-
-    (function() {
-        var interval = window.setInterval(function() {
-            for(var i=1;i<=3;i++) {
-                if(document.getElementById('gsc-i-id'+i)) {
-                    window.clearInterval(interval);
-                    document.getElementById('gsc-i-id'+i).setAttribute('placeholder', 'Search SilverStripe...');
-                }
-
+        // Define some utility functions - we can't use jQuery, from http://youmightnotneedjquery.com/.
+        function elHasClass(el, className) {
+            if (el.classList) {
+                return el.classList.contains(className);
+            } else {
+                return new RegExp('(^| )' + className + '( |$)', 'gi').test(el.className);
             }
-        }.bind(this), 500);
-    })();
+        }
 
-    (function() {
-        var cx = '$GoogleCustomSearchId';
-        var gcse = document.createElement('script'); gcse.type = 'text/javascript'; gcse.async = true;
-        gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
-            '//www.google.com/cse/cse.js?cx=' + cx;
+        function elAddClass(el, className) {
+            if (el.classList) {
+                el.classList.add(className);
+            } else {
+                el.className += ' ' + className;
+            }
+        }
+
+        function elRemoveClass(el, kls) {
+            if (el.classList) {
+                el.classList.remove(kls);
+            } else {
+                el.className = el.className.replace(' ' + kls, '');
+            }
+        }
+
+        function elToggleClass(el, className) {
+            if(el.classList) {
+                el.classList.toggle(className);
+            } else if (elHasClass(el, className)) {
+                elRemoveClass(el, className);
+            } else {
+                elAddClass(el, className);
+            }
+        }
+
+        (function() {
+            var MQL = 1170;
+            var q = function (sel) {
+                return document.querySelector(sel);
+            };
+            //primary navigation slide-in effect for pop out mega navigation
+            if(window.innerWidth > MQL) {
+                var headerHeight = q('.site-header').offsetHeight;
+                window.addEventListener('scroll', function () {
+                    var currentTop = window.scrollTop;
+                    //check if user is scrolling up
+                    if (currentTop < this.previousTop ) {
+                        //if scrolling up...
+                        if (currentTop > 0 && elHasClass(q('.site-header'),'is-fixed')) {
+                            elAddClass(q('.site-header'),'is-visible');
+                        } else {
+                            elRemoveClass(q('.site-header'),'is-visible is-fixed');
+                        }
+                    } else {
+                        //if scrolling down...
+                        elRemoveClass(q('.site-header'),'is-visible');
+                        if( currentTop > headerHeight && !elHasClass(q('.site-header'),'is-fixed')) {
+                            elAddClass(q('.site-header'),'is-fixed');
+                        }
+                    }
+                    this.previousTop = currentTop;
+                });
+            }
+
+            //open/close primary pop out mega navigation
+            var triggers = document.querySelectorAll('.js-nav-trigger');
+            [].forEach.call(triggers, function (node) {
+                node.addEventListener('click', function() {
+                    elToggleClass(q('.site-header'), 'menu-is-open');
+                    elToggleClass(q('.popup-primary-nav'),'open');
+                });
+
+            })
+        })();
+
+        (function() {
+            document.addEventListener('DOMContentLoaded', function () {
+                iFrameResize({
+                    enablePublicMethods: true,
+                    sizeWidth: true,
+                    autoResize: false,
+                    log: false
+                }, '#toolbar-iframe');
+
+                iFrameResize({
+                    enablePublicMethods: true,
+                    sizeWidth: true,
+                    autoResize: false,
+                    log: false
+                }, '#toolbar-iframe-mobile');
+
+                setTimeout(function() {
+                    document.getElementById('profile-menu').style.display='block';
+                    document.getElementById('loader-menu').style.display='none';
+                }, 1000);
+            });
+        })();
+
+        (function() {
+            var interval = window.setInterval(function() {
+                for(var i=1;i<=3;i++) {
+                    if(document.getElementById('gsc-i-id'+i)) {
+                        window.clearInterval(interval);
+                        document.getElementById('gsc-i-id'+i).setAttribute('placeholder', 'Search SilverStripe...');
+                    }
+
+                }
+            }.bind(this), 500);
+        })();
+
+        (function() {
+            var cx = '$GoogleCustomSearchId';
+            var gcse = document.createElement('script'); gcse.type = 'text/javascript'; gcse.async = true;
+            gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
+                    '//www.google.com/cse/cse.js?cx=' + cx;
             var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gcse, s);
-    })();
+        })();
 
-})();
+    })();
 
 </script>


### PR DESCRIPTION
Recent changes to the structure of the silverstripe.org sitetree have necessitated changes to the way the navigation is generated. These changes were made to the [silverstripe.org theme](https://github.com/silverstripeltd/silverstripe.org/commit/dc424a1473708c617704e13ec388d01e25f74d7c), but not to this module's version of the template, resulting in inconsistent and broken output on the community sites.